### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ vega
 altair
 altair_saver
 requests
+
+Note: altair_saver requires chromedriver or geckodriver installation to allow to save SVG or PNG.


### PR DESCRIPTION
altair_saver requires to install chromedriver or geckodriver to work with SVG or PNG file format.
( Installation on MacOS not straightforward. )